### PR TITLE
feat: add Docker containerization and CI/CD workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.git
+.github
+*.log
+open-slidex-workspace
+.open-slidex
+dist
+packages/*/dist
+packages/*/runtime
+coverage
+.DS_Store
+Thumbs.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-check:
+    name: Lint, Types & Boundary Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Check Open-Source Boundaries
+        run: npm run check:open-source-boundary
+      - name: Check Agent Skills Discoverability
+        run: npm run check:skills
+      - name: TypeCheck TypeScript
+        run: npx tsc --noEmit
+
+  test-matrix:
+    name: Test on ${{ matrix.os }} (Node ${{ matrix.node }})
+    needs: lint-and-check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [22, 24]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build Runtime
+        run: npm run build:runtime
+      - name: Run Source Tests
+        run: npm run test:source

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,86 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-only:
+    name: Validate Docker Build (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-push:
+    name: Build & Push Multi-Arch Docker Image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# ==========================================
+# OpenSlideX Containerfile
+# Multi-stage build with Chromium support
+# ==========================================
+
+# ---------- Stage 1: builder ----------
+# Builds the runtime packages. Does not need Chromium/fonts since
+# `npm run build:runtime` only bundles JS, it never launches a browser.
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Copy dependency manifests first for better layer caching
+COPY package.json package-lock.json ./
+COPY packages/editor-ui/package.json ./packages/editor-ui/
+COPY packages/open-slidex/package.json ./packages/open-slidex/
+COPY packages/open-slidex-mcp/package.json ./packages/open-slidex-mcp/
+COPY packages/slidex-sdk/package.json ./packages/slidex-sdk/
+COPY packages/slidex-workbench/package.json ./packages/slidex-workbench/
+
+# Install all workspace dependencies (including dev, needed to build)
+RUN npm ci --include=dev
+
+# Copy all source files
+COPY . .
+
+# Build production runtime packages
+RUN npm run build:runtime
+
+# Drop devDependencies now so the copy into the final stage is already lean
+RUN npm prune --omit=dev
+
+# ---------- Stage 2: runtime ----------
+FROM node:22-bookworm-slim AS runtime
+
+# Install required system dependencies for headless Chromium, Sharp, and fonts (including CJK)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium \
+    fonts-noto-cjk \
+    fonts-noto-color-emoji \
+    fonts-roboto \
+    ca-certificates \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxkbcommon0 \
+    libgbm1 \
+    libasound2 \
+    libxshmfence1 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHROME_PATH=/usr/bin/chromium \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium \
+    OPEN_SLIDEX_HOST=0.0.0.0 \
+    NODE_ENV=production
+
+WORKDIR /app
+
+# Pull the already-built app (pruned node_modules + compiled dist) from the builder stage
+COPY --from=builder /app /app
+
+# Create workspace directory and hand ownership to the unprivileged `node` user.
+# Running Chromium as root requires --no-sandbox; running as a regular user avoids that.
+RUN mkdir -p /app/open-slidex-workspace \
+    && chown -R node:node /app
+
+USER node
+
+# Expose OpenSlideX Workspace port
+EXPOSE 4172
+
+# Persist user decks
+VOLUME ["/app/open-slidex-workspace"]
+
+# Report container health via the Workspace HTTP endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:4172/workspace').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+# Default entry command
+CMD ["node", "packages/open-slidex/dist/cli.mjs", "workspace", "/app/open-slidex-workspace", "--port", "4172", "--no-open"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  open-slidex:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: open-slidex:latest
+    container_name: open-slidex-workspace
+    restart: unless-stopped
+    ports:
+      - "4172:4172"
+    environment:
+      - OPEN_SLIDEX_HOST=0.0.0.0
+      - NODE_ENV=production
+    volumes:
+      # Mount your local presentations folder into the container.
+      # Override with WORKSPACE_PATH=/path/to/decks docker compose up -d
+      - ${WORKSPACE_PATH:-./open-slidex-workspace}:/app/open-slidex-workspace
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4172/workspace').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3

--- a/docs/DOCKER_AND_CICD.md
+++ b/docs/DOCKER_AND_CICD.md
@@ -1,0 +1,140 @@
+# OpenSlideX 容器化與 CI/CD 指南
+
+本文件說明如何使用 Docker 執行 OpenSlideX，以及如何在 GitHub 上設定與驗證 CI/CD 工作流程。
+
+---
+
+## 目錄
+
+1. [Docker 容器化指南](#一docker-容器化指南)
+   - [快速啟動 (Docker Compose)](#1-快速啟動-docker-compose-推薦)
+   - [手動建置與執行 (Docker CLI)](#2-手動建置與執行-docker-cli)
+   - [環境變數與目錄掛載說明](#3-環境變數與目錄掛載說明)
+2. [CI/CD 自動化流程](#二cicd-自動化流程)
+   - [持續整合 (CI Pipeline)](#1-持續整合-ci-pipeline)
+   - [Docker 建置與發布 (CD Pipeline)](#2-docker-建置與發布-cd-pipeline)
+   - [獨立發行版 (Standalone Release)](#3-獨立發行版-standalone-release)
+3. [提交 PR 前的驗證步驟](#三提交-pr-前的驗證步驟)
+
+---
+
+## 一、Docker 容器化指南
+
+專案已提供包含無頭 Chromium、Noto CJK 字型與預先編譯 Runtime 的 `Dockerfile`。
+
+### 1. 快速啟動 (Docker Compose 推薦)
+
+```bash
+# 建置並啟動容器
+docker compose up -d
+
+# 查看運行日誌
+docker compose logs -f
+
+# 停止並移除容器
+docker compose down
+```
+
+啟動後，於瀏覽器開啟：<http://localhost:4172/workspace>
+
+### 2. 手動建置與執行 (Docker CLI)
+
+```bash
+# 1. 建置 Image
+docker build -t open-slidex:latest .
+
+# 2. 執行 Container 並掛載本機 Workspace
+docker run -d \
+  --name open-slidex-workspace \
+  -p 4172:4172 \
+  -v "$(pwd)/open-slidex-workspace:/app/open-slidex-workspace" \
+  open-slidex:latest
+```
+
+### 3. 環境變數與目錄掛載說明
+
+- **服務埠 (Port)**：`4172`（OpenSlideX Workspace 預設監聽埠）
+
+- **環境變數**：
+  - `OPEN_SLIDEX_HOST=0.0.0.0`：允許容器外部連線。
+  - `NODE_ENV=production`：以生產模式啟動。
+  - `WORKSPACE_PATH`（可選）：覆寫 `docker-compose.yml` 中掛載到容器的本機簡報資料夾路徑，預設為 `./open-slidex-workspace`。
+
+- **資料掛載 (Volume Mount)**：
+  - 容器內路徑：`/app/open-slidex-workspace`
+  - 建議掛載到本機資料夾，確保新增與編輯的簡報在容器重啟後仍會保留。
+
+---
+
+## 二、CI/CD 自動化流程
+
+專案已在 `.github/workflows/` 設定以下自動化工作流程：
+
+### 1. 持續整合 (CI Pipeline) — `.github/workflows/ci.yml`
+
+- **觸發條件**：推送到 `main` 分支的 Push，或針對 `main` 分支的 Pull Request。
+
+- **執行內容**：
+  1. **Lint 與邊界檢查**：
+     - 開源邊界檢查（`npm run check:open-source-boundary`）
+     - Agent Skills 可發現性檢查（`npm run check:skills`）
+     - TypeScript 型別檢查（`npx tsc --noEmit`）
+  2. **多平台矩陣測試 (Matrix Test)**：
+     - 作業系統：`ubuntu-latest`、`macos-latest`、`windows-latest`
+     - Node.js 版本：`22`、`24`
+     - 執行完整單元與整合測試（`npm run test:source`）
+
+### 2. Docker 建置與發布 (CD Pipeline) — `.github/workflows/docker-publish.yml`
+
+- **PR 驗證 (build-only)**：針對 `main` 分支的 Pull Request，僅建置 Docker image 以確認 `Dockerfile` 可正常建置，不會推送 image。
+
+- **正式發布 (build-and-push)**：Push 到 `main` 分支，或發布 `v*` Tag，亦支援手動觸發（`workflow_dispatch`）。
+  - 透過 QEMU 與 Docker Buildx 建置多架構映像檔（支援 `linux/amd64` 與 `linux/arm64`）。
+  - 自動標記並發布到 **GitHub Container Registry (ghcr.io)**。
+  - 使用者拉取映像檔範例：
+
+    ```bash
+    docker pull ghcr.io/<owner>/open-slidex:latest
+    ```
+
+### 3. 獨立發行版 (Standalone Release) — `.github/workflows/standalone-release.yml`
+
+- **觸發條件**：推送版本 Tag（如 `v0.4.0`）。
+
+- **執行內容**：
+  - 自動編譯包含私有 Node.js 與 Chromium 的可攜式套件（支援 macOS ARM/Intel、Windows x64）。
+  - 自動計算 SHA-256 Checksum 並建立 GitHub Release。
+
+---
+
+## 三、提交 PR 前的驗證步驟
+
+### 1. 本機驗證測試
+
+```bash
+# 1. 型別檢查
+npx tsc --noEmit
+
+# 2. 執行所有原始碼測試
+npm run test:source
+
+# 3. 驗證 Runtime 建置
+npm run build:runtime
+```
+
+### 2. Docker 本機驗證
+
+```bash
+# 建置並啟動 Docker
+docker compose build
+docker compose up -d
+
+# 測試服務是否回應
+curl -I http://localhost:4172/workspace
+```
+
+### 3. GitHub Actions 驗證
+
+1. 將程式碼推送到 GitHub 遠端儲存庫的 feature branch。
+2. 建立 Pull Request 至 `main` 分支，確認 GitHub Actions 的 **CI** 與 **Docker Publish（build-only）** 都能通過。
+3. 合併至 `main` 後，確認 **Docker Publish** 自動建置並推送 GitHub Package。

--- a/packages/slidex-workbench/src/cli.ts
+++ b/packages/slidex-workbench/src/cli.ts
@@ -57,6 +57,7 @@ async function main() {
       createSlideXWorkbenchViteConfig(options: {
         apiPort: number;
         cacheDir: string;
+        host?: string;
         port: number;
         sourceRoot: string;
         workspaceUrl?: string;
@@ -65,6 +66,7 @@ async function main() {
     const vite = await createViteServer(createSlideXWorkbenchViteConfig({
       apiPort: running.port,
       cacheDir: path.join(workspace.stateRoot, "vite-cache"),
+      host: process.env.OPEN_SLIDEX_HOST,
       port,
       sourceRoot,
       workspaceUrl

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -159,8 +159,13 @@ export function createSlideXWorkbenchViteConfig(options = {}) {
     ...(apiTarget
       ? {
           server: {
+            // Non-loopback hosts (e.g. 0.0.0.0 for container port publishing) are an
+            // explicit opt-in, so Vite's DNS-rebinding host check is disabled to match.
+            ...(options.host && options.host !== "127.0.0.1" && options.host !== "localhost"
+              ? { allowedHosts: true }
+              : {}),
             fs: { allow: [sourceRoot, robotoPackageRoot] },
-            host: "127.0.0.1",
+            host: options.host ?? "127.0.0.1",
             port: options.port ?? 4173,
             proxy: {
               "/api/v1": localWorkbenchProxy(apiTarget),


### PR DESCRIPTION
## Summary
- Multi-stage `Dockerfile` (builder compiles the runtime and prunes devDependencies; runtime stage installs headless Chromium + CJK fonts, drops to a non-root user, and reports health via the Workspace HTTP endpoint)
- `docker-compose.yml` with a configurable `WORKSPACE_PATH` volume and matching healthcheck
- `.github/workflows/ci.yml` — lint/typecheck/boundary checks + OS/Node matrix tests
- `.github/workflows/docker-publish.yml` — PR runs build-only validation (no push); pushes to `main`/`v*` tags build and push multi-arch images to GHCR
- `docs/DOCKER_AND_CICD.md` — usage and CI/CD guide
- Fix: the Workspace Vite dev server's `host` was hardcoded to `127.0.0.1`, so `OPEN_SLIDEX_HOST` was silently ignored and the container was unreachable through a published port even though the TCP connection succeeded. Wired the env var through `createSlideXWorkbenchViteConfig` and scoped Vite's `allowedHosts` bypass to only when a non-loopback host is explicitly requested. The internal API server stays loopback-only as before.

## Test plan
- [x] `docker compose build` — multi-stage build succeeds
- [x] `docker compose up -d` — container reports `healthy`
- [x] `curl http://localhost:4172/workspace` from the host — 200 (previously: connection accepted, empty reply)
- [x] `curl http://localhost:4172/api/v1/workspace` from the host — 200, proxied through to the internal API server
- [x] `npx tsc --noEmit` — no new type errors introduced by this change
- [x] `node --test scripts/slidex-workbench-vite-config.test.mjs` — no regressions (one pre-existing Windows path-separator failure, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)