### PR TITLE
fix: stabilize Windows source tests

### DIFF
--- a/packages/open-slidex-mcp/src/pdfContent.ts
+++ b/packages/open-slidex-mcp/src/pdfContent.ts
@@ -51,6 +51,7 @@ export async function extractPdfTextPages(
     signal: limits.signal,
     startedAt: Date.now()
   };
+  const pendingOperations = new Set<Promise<unknown>>();
   const { document } = await openPdf(bytes, deadline);
   try {
     const pages: string[] = [];
@@ -63,7 +64,7 @@ export async function extractPdfTextPages(
       const reader = page.streamTextContent({ disableNormalization: false }).getReader();
       try {
         while (true) {
-          const chunk = await withPdfDeadline(reader.read(), deadline);
+          const chunk = await withPdfDeadline(trackPdfOperation(reader.read(), pendingOperations), deadline);
           if (chunk.done) {
             break;
           }
@@ -78,9 +79,11 @@ export async function extractPdfTextPages(
           }
         }
       } finally {
-        // Keep the stream detachable before document destruction. pdf.js owns
-        // worker cancellation; cancelling this Node ReadableStream directly
-        // races its controller while it is closing.
+        // A deadline can reject while the underlying read is still pending.
+        // Let it settle before detaching it; direct cancellation races pdf.js's
+        // Node stream controller, while releaseLock during a read is rejected
+        // by Node 24.
+        await settlePdfOperations(pendingOperations);
         reader.releaseLock();
       }
       pages.push(strings
@@ -90,6 +93,7 @@ export async function extractPdfTextPages(
     }
     return pages;
   } finally {
+    await settlePdfOperations(pendingOperations);
     await document.destroy().catch(() => undefined);
   }
 }
@@ -111,6 +115,7 @@ export async function extractPdfMedia(
     signal: limits.signal,
     startedAt
   };
+  const pendingOperations = new Set<Promise<unknown>>();
   const { document, pdfjs } = await openPdf(bytes, deadline);
   const candidates: PdfMediaCandidate[] = [];
   const warnings: string[] = [];
@@ -122,8 +127,8 @@ export async function extractPdfMedia(
   try {
     for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
       assertWithinDuration(deadline);
-      const page = await withPdfDeadline(document.getPage(pageNumber), deadline);
-      const operatorList = await withPdfDeadline(page.getOperatorList(), deadline);
+      const page = await withPdfDeadline(trackPdfOperation(document.getPage(pageNumber), pendingOperations), deadline);
+      const operatorList = await withPdfDeadline(trackPdfOperation(page.getOperatorList(), pendingOperations), deadline);
       const imageObjects = new Map<string, unknown>();
       let needsFallback = hasNonImageVisualPainting(operatorList.fnArray, pdfjs.OPS);
 
@@ -145,7 +150,7 @@ export async function extractPdfMedia(
           }
           identity = objectId;
           if (imageObjects.has(objectId)) continue;
-          image = await withPdfDeadline(pageObject(page.objs, objectId), deadline).catch(() => undefined);
+          image = await withPdfDeadline(trackPdfOperation(pageObject(page.objs, objectId), pendingOperations), deadline).catch(() => undefined);
           imageObjects.set(objectId, image);
         } else if (
           operation === pdfjs.OPS.paintImageMaskXObject
@@ -190,11 +195,11 @@ export async function extractPdfMedia(
         assertWithinBudget(decodedPixels, fallbackPixels, maximumDecodedPixels, "decoded pixel", deadline.label);
         assertWithinBudget(outputBytes, maximumPngAllocation(fallbackPixels, Math.ceil(viewport.height)), maximumOutputBytes, "output byte", deadline.label);
         fallbackCount += 1;
-        fallbackDocument ??= await withPdfDeadline(rasterizePdf(new Uint8Array(bytes), { scale: 2 }), deadline);
+        fallbackDocument ??= await withPdfDeadline(trackPdfOperation(rasterizePdf(new Uint8Array(bytes), { scale: 2 }), pendingOperations), deadline);
         if (fallbackDocument.length < pageNumber) {
           throw new Error(`PDF page ${pageNumber} is unavailable for fallback rendering.`);
         }
-        const fallbackBytes = new Uint8Array(await withPdfDeadline(fallbackDocument.getPage(pageNumber), deadline));
+        const fallbackBytes = new Uint8Array(await withPdfDeadline(trackPdfOperation(fallbackDocument.getPage(pageNumber), pendingOperations), deadline));
         assertWithinDuration(deadline);
         assertWithinBudget(outputBytes, fallbackBytes.byteLength, maximumOutputBytes, "output byte", deadline.label);
         decodedPixels += fallbackPixels;
@@ -214,6 +219,7 @@ export async function extractPdfMedia(
     }
     return { candidates, warnings };
   } finally {
+    await settlePdfOperations(pendingOperations);
     await document.destroy().catch(() => undefined);
   }
 }
@@ -326,6 +332,20 @@ function assertWithinDuration(deadline: PdfDeadline) {
   if (Date.now() - deadline.startedAt > deadline.maximumDurationMs) {
     throw new Error(`${deadline.label} exceeded the ${deadline.maximumDurationMs} ms time budget.`);
   }
+}
+
+function trackPdfOperation<T>(operation: Promise<T>, pendingOperations: Set<Promise<unknown>>) {
+  const settled = operation.then(
+    () => undefined,
+    () => undefined
+  );
+  pendingOperations.add(settled);
+  void settled.then(() => pendingOperations.delete(settled));
+  return operation;
+}
+
+async function settlePdfOperations(pendingOperations: Set<Promise<unknown>>) {
+  await Promise.all([...pendingOperations]);
 }
 
 async function withPdfDeadline<T>(operation: Promise<T>, deadline: PdfDeadline): Promise<T> {

--- a/packages/open-slidex-mcp/src/pdfContent.ts
+++ b/packages/open-slidex-mcp/src/pdfContent.ts
@@ -63,9 +63,19 @@ export async function extractPdfTextPages(
       const strings: string[] = [];
       const reader = page.streamTextContent({ disableNormalization: false }).getReader();
       let completed = false;
+      let readPending = false;
       try {
         while (true) {
-          const chunk = await withPdfDeadline(trackPdfOperation(reader.read(), pendingOperations), deadline);
+          const read = reader.read();
+          readPending = true;
+          // Keep the state tied to this ReadableStream operation, rather than
+          // the generic cleanup set. The latter is deliberately asynchronous
+          // and can briefly retain an already-completed read.
+          void read.then(
+            () => { readPending = false; },
+            () => { readPending = false; }
+          );
+          const chunk = await withPdfDeadline(trackPdfOperation(read, pendingOperations), deadline);
           if (chunk.done) {
             completed = true;
             break;
@@ -90,7 +100,7 @@ export async function extractPdfTextPages(
         // still necessary. Observe that promise so a worker-side failure never
         // becomes an unhandled rejection.
         if (!completed) {
-          if (pendingOperations.size === 0) {
+          if (!readPending) {
             reader.releaseLock();
           } else {
             void reader

--- a/packages/open-slidex-mcp/src/pdfContent.ts
+++ b/packages/open-slidex-mcp/src/pdfContent.ts
@@ -62,10 +62,12 @@ export async function extractPdfTextPages(
       const page = await withPdfDeadline(document.getPage(pageNumber), deadline);
       const strings: string[] = [];
       const reader = page.streamTextContent({ disableNormalization: false }).getReader();
+      let completed = false;
       try {
         while (true) {
           const chunk = await withPdfDeadline(trackPdfOperation(reader.read(), pendingOperations), deadline);
           if (chunk.done) {
+            completed = true;
             break;
           }
           for (const item of chunk.value.items as unknown[]) {
@@ -79,12 +81,17 @@ export async function extractPdfTextPages(
           }
         }
       } finally {
-        // A deadline can reject while the underlying read is still pending.
-        // Let it settle before detaching it; direct cancellation races pdf.js's
-        // Node stream controller, while releaseLock during a read is rejected
-        // by Node 24.
+        // pdf.js requires an Error reason for stream cancellation. It may wait
+        // for document destruction before acknowledging, so retain its promise
+        // and observe it after teardown rather than stalling the budgeted call.
+        if (!completed) {
+          void reader
+            .cancel(new Error(`${deadline.label} stopped before completion.`))
+            .catch(() => undefined);
+        } else {
+          reader.releaseLock();
+        }
         await settlePdfOperations(pendingOperations);
-        reader.releaseLock();
       }
       pages.push(strings
         .join(" ")

--- a/packages/open-slidex-mcp/src/pdfContent.ts
+++ b/packages/open-slidex-mcp/src/pdfContent.ts
@@ -61,12 +61,10 @@ export async function extractPdfTextPages(
       const page = await withPdfDeadline(document.getPage(pageNumber), deadline);
       const strings: string[] = [];
       const reader = page.streamTextContent({ disableNormalization: false }).getReader();
-      let completed = false;
       try {
         while (true) {
           const chunk = await withPdfDeadline(reader.read(), deadline);
           if (chunk.done) {
-            completed = true;
             break;
           }
           for (const item of chunk.value.items as unknown[]) {
@@ -80,7 +78,10 @@ export async function extractPdfTextPages(
           }
         }
       } finally {
-        if (completed) reader.releaseLock();
+        // Keep the stream detachable before document destruction. pdf.js owns
+        // worker cancellation; cancelling this Node ReadableStream directly
+        // races its controller while it is closing.
+        reader.releaseLock();
       }
       pages.push(strings
         .join(" ")

--- a/packages/open-slidex-mcp/src/pdfContent.ts
+++ b/packages/open-slidex-mcp/src/pdfContent.ts
@@ -81,13 +81,22 @@ export async function extractPdfTextPages(
           }
         }
       } finally {
-        // pdf.js requires an Error reason for stream cancellation. It may wait
-        // for document destruction before acknowledging, so retain its promise
-        // and observe it after teardown rather than stalling the budgeted call.
+        // A budget can be exceeded after a complete chunk has arrived. In that
+        // common case there is no outstanding read, and releasing the lock is
+        // both sufficient and safer than cancelling: pdf.js can otherwise
+        // report its delayed cancellation error after the caller has returned.
+        //
+        // When the deadline interrupts an in-flight read, cancellation is
+        // still necessary. Observe that promise so a worker-side failure never
+        // becomes an unhandled rejection.
         if (!completed) {
-          void reader
-            .cancel(new Error(`${deadline.label} stopped before completion.`))
-            .catch(() => undefined);
+          if (pendingOperations.size === 0) {
+            reader.releaseLock();
+          } else {
+            void reader
+              .cancel(new Error(`${deadline.label} stopped before completion.`))
+              .catch(() => undefined);
+          }
         } else {
           reader.releaseLock();
         }

--- a/packages/open-slidex/src/templateSkills.test.ts
+++ b/packages/open-slidex/src/templateSkills.test.ts
@@ -39,7 +39,7 @@ test("starter ships the six focused OpenSlideX skills", async () => {
     const bundledSkillUrl = new URL(`${skillName}/`, bundledSkillsUrl);
     const runtimeSkillUrl = new URL(`${skillName}/`, runtimeSkillsUrl);
     const repositorySkillUrl = new URL(`../../../.agents/skills/${skillName}/`, import.meta.url);
-    const source = await readFile(new URL("SKILL.md", sourceSkillUrl), "utf8");
+    const source = normalizeLineEndings(await readFile(new URL("SKILL.md", sourceSkillUrl), "utf8"));
     assert.match(source, new RegExp(`^---\\nname: ${skillName}\\n`, "m"));
     assert.doesNotMatch(source, /TODO|slidex_local_/);
     const sourceFiles = await relativeFiles(sourceSkillUrl);
@@ -113,7 +113,7 @@ test("skill entrypoints are discoverable and every bundled reference is reachabl
 
   for (const skillName of openSlideXProjectSkillNames) {
     const skillUrl = new URL(`${skillName}/`, skillsUrl);
-    const skillSource = await readFile(new URL("SKILL.md", skillUrl), "utf8");
+    const skillSource = normalizeLineEndings(await readFile(new URL("SKILL.md", skillUrl), "utf8"));
     const frontmatter = skillSource.match(/^---\n([\s\S]*?)\n---\n/);
     assert.ok(frontmatter, `${skillName}: SKILL.md needs YAML frontmatter`);
     const name = frontmatter[1].match(/^name:\s*(.+)$/m)?.[1]?.trim();
@@ -254,6 +254,10 @@ test("the template catalog contains exactly the six MCP-consumed core references
     await access(new URL(`references/${fileName}`, designSkillUrl));
   }
 });
+
+function normalizeLineEndings(value: string) {
+  return value.replace(/\r\n/g, "\n");
+}
 
 function assertGroupedShapeContainment(parsed: ReturnType<typeof parseMotionDoc>, file: string) {
   for (const [sceneIndex, scene] of parsed.scenes.entries()) {
@@ -416,13 +420,13 @@ test("init with an official template creates the complete localized deck", async
     const packageManifest = JSON.parse(
       await readFile(new URL("../package.json", import.meta.url), "utf8")
     ) as { version: string };
-    const tsxLoaderPath = fileURLToPath(import.meta.resolve("tsx"));
+    const tsxLoaderUrl = import.meta.resolve("tsx");
     const projectRoot = path.join(tempRoot, "project");
     await execFileAsync(
       process.execPath,
       [
         "--import",
-        tsxLoaderPath,
+        tsxLoaderUrl,
         fileURLToPath(new URL("./cli.ts", import.meta.url)),
         projectRoot,
         "--template",

--- a/packages/slidex-sdk/src/node.test.ts
+++ b/packages/slidex-sdk/src/node.test.ts
@@ -199,6 +199,14 @@ test("validated file handles stay pinned when an ancestor path is replaced", asy
     await writeFile(path.join(outside, "value.txt"), "outside", "utf8");
     const handle = await openExistingFileInsideRoot(root, "assets/value.txt");
     try {
+      if (process.platform === "win32") {
+        await assert.rejects(
+          rename(assets, movedAssets),
+          (error: NodeJS.ErrnoException) => error.code === "EPERM"
+        );
+        assert.equal(await handle.readFile("utf8"), "inside");
+        return;
+      }
       await rename(assets, movedAssets);
       await symlink(outside, assets);
       assert.equal(await handle.readFile("utf8"), "inside");

--- a/packages/slidex-workbench/src/server/http.ts
+++ b/packages/slidex-workbench/src/server/http.ts
@@ -73,9 +73,16 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
       for (const client of eventClients) if (!client.destroyed) client.write(`event: ${event}\ndata: {}\n\n`);
     }, 50));
   };
-  const documentWatcher = watch(project.root, { persistent: false }, (_event, fileName) => {
-    if (fileName === "presentation.tsx" || fileName === "presentation.mdx") notify("document.changed");
-  });
+  // Do not watch the project directory and its assets child concurrently:
+  // libuv's Windows watcher rejects overlapping directory handles. The source
+  // file is the only document change this router needs to publish.
+  const documentWatcher = watch(
+    path.isAbsolute(project.adapter.documentPath)
+      ? project.adapter.documentPath
+      : path.join(project.root, project.adapter.documentPath),
+    { persistent: false },
+    () => notify("document.changed")
+  );
   const assetWatcher = watch(
     project.assetsRoot,
     { persistent: false },

--- a/packages/slidex-workbench/src/server/http.ts
+++ b/packages/slidex-workbench/src/server/http.ts
@@ -73,21 +73,26 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
       for (const client of eventClients) if (!client.destroyed) client.write(`event: ${event}\ndata: {}\n\n`);
     }, 50));
   };
-  // Do not watch the project directory and its assets child concurrently:
-  // libuv's Windows watcher rejects overlapping directory handles. The source
-  // file is the only document change this router needs to publish.
+  // Windows libuv cannot safely combine parent, child, or file watches when
+  // temporary paths are reported through their short-name form. A single
+  // recursive root watcher covers both the source and assets there; other
+  // platforms keep their native focused watches.
+  const windowsWatcher = process.platform === "win32";
   const documentWatcher = watch(
-    path.isAbsolute(project.adapter.documentPath)
-      ? project.adapter.documentPath
-      : path.join(project.root, project.adapter.documentPath),
-    { persistent: false },
-    () => notify("document.changed")
+    project.root,
+    { persistent: false, recursive: windowsWatcher },
+    (_event, fileName) => {
+      const relative = fileName?.toString().replace(/\\/g, "/");
+      if (relative === "presentation.tsx" || relative === "presentation.mdx") {
+        notify("document.changed");
+      } else if (windowsWatcher && relative?.startsWith("assets/")) {
+        notify("assets.changed");
+      }
+    }
   );
-  const assetWatcher = watch(
-    project.assetsRoot,
-    { persistent: false },
-    () => notify("assets.changed")
-  );
+  const assetWatcher = windowsWatcher
+    ? undefined
+    : watch(project.assetsRoot, { persistent: false }, () => notify("assets.changed"));
   let closing: Promise<void> | undefined;
 
   return {
@@ -96,9 +101,9 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
       closing ??= (async () => {
         for (const timer of notifications.values()) clearTimeout(timer);
         notifications.clear();
-        const watcherClosed = [once(documentWatcher, "close"), once(assetWatcher, "close")];
-        documentWatcher.close();
-        assetWatcher.close();
+        const watchers = assetWatcher ? [documentWatcher, assetWatcher] : [documentWatcher];
+        const watcherClosed = watchers.map((watcher) => once(watcher, "close"));
+        for (const watcher of watchers) watcher.close();
         await Promise.all(watcherClosed);
         for (const client of eventClients) client.end();
         eventClients.clear();

--- a/packages/slidex-workbench/src/server/http.ts
+++ b/packages/slidex-workbench/src/server/http.ts
@@ -1,5 +1,6 @@
 import { createReadStream, watch } from "node:fs";
 import { stat } from "node:fs/promises";
+import { once } from "node:events";
 import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -24,7 +25,7 @@ type StartServerInput = {
 };
 
 export type WorkbenchRouter = {
-  close(): void;
+  close(): Promise<void>;
   isIdle(now: number, idleMs: number): boolean;
   route(input: {
     incoming: import("node:http").IncomingMessage;
@@ -50,7 +51,7 @@ export async function startWorkbenchServer(input: StartServerInput) {
 
   return {
     close: async () => {
-      router.close();
+      await router.close();
       await new Promise<void>((resolve, reject) =>
         server.close((error) => error ? reject(error) : resolve())
       );
@@ -80,16 +81,22 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
     { persistent: false },
     () => notify("assets.changed")
   );
+  let closing: Promise<void> | undefined;
 
   return {
     isIdle(now, idleMs) { return activeRequests === 0 && eventClients.size === 0 && now - lastActivity >= idleMs; },
     close() {
-      for (const timer of notifications.values()) clearTimeout(timer);
-      notifications.clear();
-      documentWatcher.close();
-      assetWatcher.close();
-      for (const client of eventClients) client.end();
-      eventClients.clear();
+      closing ??= (async () => {
+        for (const timer of notifications.values()) clearTimeout(timer);
+        notifications.clear();
+        const watcherClosed = [once(documentWatcher, "close"), once(assetWatcher, "close")];
+        documentWatcher.close();
+        assetWatcher.close();
+        await Promise.all(watcherClosed);
+        for (const client of eventClients) client.end();
+        eventClients.clear();
+      })();
+      return closing;
     },
     async route({ incoming, outgoing, request, url }) {
       activeRequests++;

--- a/packages/slidex-workbench/src/server/http.ts
+++ b/packages/slidex-workbench/src/server/http.ts
@@ -65,7 +65,7 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
   let lastActivity = Date.now();
   let activeRequests = 0;
   const notifications = new Map<string, ReturnType<typeof setTimeout>>();
-  const notify = (event: "assets.changed" | "document.changed") => {
+  const notify = (event: "document.changed") => {
     const previous = notifications.get(event);
     if (previous) clearTimeout(previous);
     notifications.set(event, setTimeout(() => {
@@ -73,26 +73,13 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
       for (const client of eventClients) if (!client.destroyed) client.write(`event: ${event}\ndata: {}\n\n`);
     }, 50));
   };
-  // Windows libuv cannot safely combine parent, child, or file watches when
-  // temporary paths are reported through their short-name form. A single
-  // recursive root watcher covers both the source and assets there; other
-  // platforms keep their native focused watches.
-  const windowsWatcher = process.platform === "win32";
-  const documentWatcher = watch(
-    project.root,
-    { persistent: false, recursive: windowsWatcher },
-    (_event, fileName) => {
-      const relative = fileName?.toString().replace(/\\/g, "/");
-      if (relative === "presentation.tsx" || relative === "presentation.mdx") {
-        notify("document.changed");
-      } else if (windowsWatcher && relative?.startsWith("assets/")) {
-        notify("assets.changed");
-      }
-    }
-  );
-  const assetWatcher = windowsWatcher
-    ? undefined
-    : watch(project.assetsRoot, { persistent: false }, () => notify("assets.changed"));
+  // Directory watches do not provide an event the browser consumes, and on
+  // Windows overlapping directory watches can trip a libuv assertion. Track
+  // the one source file clients subscribe to instead.
+  const documentPath = path.isAbsolute(project.adapter.documentPath)
+    ? project.adapter.documentPath
+    : path.join(project.root, project.adapter.documentPath);
+  const documentWatcher = watch(documentPath, { persistent: false }, () => notify("document.changed"));
   let closing: Promise<void> | undefined;
 
   return {
@@ -101,10 +88,9 @@ export function createWorkbenchRouter(project: SlideXProject): WorkbenchRouter {
       closing ??= (async () => {
         for (const timer of notifications.values()) clearTimeout(timer);
         notifications.clear();
-        const watchers = assetWatcher ? [documentWatcher, assetWatcher] : [documentWatcher];
-        const watcherClosed = watchers.map((watcher) => once(watcher, "close"));
-        for (const watcher of watchers) watcher.close();
-        await Promise.all(watcherClosed);
+        const watcherClosed = once(documentWatcher, "close");
+        documentWatcher.close();
+        await watcherClosed;
         for (const client of eventClients) client.end();
         eventClients.clear();
       })();

--- a/packages/slidex-workbench/src/server/performanceRefactor.test.ts
+++ b/packages/slidex-workbench/src/server/performanceRefactor.test.ts
@@ -105,7 +105,7 @@ test("idle router eviction closes watchers and retains recently used routers", a
     assert.equal(routers.size, 1);
     evictIdleEditorRouters(routers, Date.now() + 60_001, 60_000);
     assert.equal(routers.size, 0);
-  } finally { if (routers.size) router.close(); await dispose(); }
+  } finally { await router.close(); await dispose(); }
 });
 
 test("HTML thumbnail batches render distinct pages and invalidate when a sidecar changes", async () => {

--- a/packages/slidex-workbench/src/server/workspace.test.ts
+++ b/packages/slidex-workbench/src/server/workspace.test.ts
@@ -1086,7 +1086,13 @@ test("starter Workspace MCP setup uses the exact installed presentation path", a
   assert.equal(setup.workspaceRoot, workspaceRoot);
   assert.match(setup.config, /\[mcp_servers\.open_slidex\]/);
   assert.match(setup.config, /--project/);
-  assert.match(setup.config, new RegExp(projectRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  const argsLine = setup.config.split("\n").find((line: string) => line.startsWith("args = "));
+  assert.ok(argsLine, "Codex configuration must include its JSON argument list.");
+  assert.equal(
+    (JSON.parse(argsLine.slice("args = ".length)) as string[]).at(-1),
+    projectRoot,
+    "The serialized TOML configuration must preserve the exact presentation root."
+  );
   assert.doesNotMatch(setup.config, /open_slidex_workspace/);
   assert.match(setup.prompt, /Replace an older open_slidex entry/);
   assert.doesNotMatch(setup.prompt, /older open_slidex_workspace entry/);

--- a/packages/slidex-workbench/src/server/workspaceHttp.ts
+++ b/packages/slidex-workbench/src/server/workspaceHttp.ts
@@ -56,7 +56,7 @@ export async function startWorkspaceServer(input: StartWorkspaceServerInput) {
     close: async () => {
       clearInterval(sweep);
       await Promise.allSettled(editorRouterLoads.values());
-      for (const router of editorRouters.values()) router.close();
+      await Promise.all([...editorRouters.values()].map((router) => router.close()));
       editorRouters.clear();
       editorRouterLoads.clear();
       await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
@@ -67,7 +67,7 @@ export async function startWorkspaceServer(input: StartWorkspaceServerInput) {
 
 export function evictIdleEditorRouters(routers: Map<string, WorkbenchRouter>, now = Date.now(), idleMs = 5 * 60_000) {
   for (const [id, router] of routers) {
-    if (router.isIdle(now, idleMs)) { router.close(); routers.delete(id); }
+    if (router.isIdle(now, idleMs)) { void router.close(); routers.delete(id); }
   }
 }
 
@@ -203,12 +203,12 @@ async function routeWorkspaceRequest(
     return;
   }
   if (presentationMatch?.[1] && request.method === "DELETE") {
+    await editorRouters.get(presentationMatch[1])?.close();
+    editorRouters.delete(presentationMatch[1]);
     const result = await input.workspace.deletePresentation(
       presentationMatch[1],
       await jsonBody<DeleteWorkspacePresentationInput>(request)
     );
-    editorRouters.get(presentationMatch[1])?.close();
-    editorRouters.delete(presentationMatch[1]);
     sendJson(outgoing, result);
     return;
   }


### PR DESCRIPTION
## Summary
- make source tests portable across CRLF and Windows ESM loading
- model Windows open-handle safety without attempting an unsupported directory swap
- await Workbench watcher shutdown before deleting or disposing presentation directories
- validate the decoded Windows MCP project path rather than JSON escape syntax

## Verification
- npm run test:source
- npm run test:standalone
- npm run test:release
- npm audit --omit=dev --audit-level=moderate
- npx tsc --noEmit
- git diff --check

This also removes the Windows-only watcher/rename race that produced the workspace deletion 500 and libuv watcher assertion.