### PR TITLE
fix: bootstrap GitHub CLI for Windows install

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@ OpenSlideX は、編集可能なプレゼンテーションのための、オー
 
 ## Node.js や Git を使わないインストール
 
-スタンドアロンインストーラーは、専用の Node.js 実行ファイルと Chromium renderer を含む OpenSlideX ランタイム一式をダウンロードします。npm、Git、システム全体の Node.js はインストールせず、管理者権限も不要です。
+スタンドアロンインストーラーは、専用の Node.js 実行ファイルと Chromium renderer を含む OpenSlideX ランタイム一式をダウンロードします。npm、Git、システム全体の Node.js はインストールしません。Windows で release 検証用に GitHub CLI を導入する際は、昇格が求められる場合があります。
 
 macOS:
 
@@ -28,7 +28,6 @@ Windows PowerShell:
 
 ```powershell
 irm https://github.com/zz41354899/open-slidex/releases/latest/download/install.ps1 -OutFile install.ps1
-gh attestation verify install.ps1 --repo zz41354899/open-slidex
 .\install.ps1
 ```
 
@@ -41,7 +40,7 @@ slidex rollback    # 保持している直前の正常バージョンへ戻す
 slidex uninstall   # ランタイムとコマンドを削除し、プレゼンテーションは残す
 ```
 
-既定のライブラリは、macOS では `~/Documents/OpenSlideX Workspace`、Windows では現在のユーザーの Documents フォルダです。ダウンロードする release archive は SHA-256 checksum で検証されます。
+既定のライブラリは、macOS では `~/Documents/OpenSlideX Workspace`、Windows では現在のユーザーの Documents フォルダです。ダウンロードする release archive は SHA-256 checksum と GitHub artifact attestation で検証されます。Windows では必要に応じてインストーラーが Windows Package Manager（`winget`）で GitHub CLI（`gh`）を導入してから release を検証します。macOS では `gh` をあらかじめ利用可能にしてください。
 
 ## 開発者向けクイックスタート
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Click the preview to [watch the OpenSlideX Workspace demo](https://www.slidexdec
 
 The standalone installer downloads the complete OpenSlideX runtime, including
 its private Node.js executable and Chromium renderer. It does not install npm,
-Git, or system-wide Node.js and does not require administrator access.
+Git, or system-wide Node.js. Windows may request elevation to install GitHub CLI
+for release verification.
 
 macOS:
 
@@ -34,7 +35,6 @@ Windows PowerShell:
 
 ```powershell
 irm https://github.com/zz41354899/open-slidex/releases/latest/download/install.ps1 -OutFile install.ps1
-gh attestation verify install.ps1 --repo zz41354899/open-slidex
 .\install.ps1
 ```
 
@@ -51,9 +51,10 @@ The default presentation library is `~/Documents/OpenSlideX Workspace` on
 macOS and the current user's Documents folder on Windows. Every downloaded
 release archive must pass both SHA-256 integrity and GitHub artifact-attestation
 verification before it can replace the active version. Release archives include
-an attested SPDX SBOM. The installer therefore requires GitHub CLI (`gh`) for
-normal GitHub releases; local test mirrors remain explicitly isolated from this
-production verification path.
+an attested SPDX SBOM. On Windows, the installer uses Windows Package Manager
+(`winget`) to install GitHub CLI (`gh`) when needed, then verifies the release;
+macOS requires `gh` to be available. Local test mirrors remain explicitly
+isolated from this production verification path.
 
 ## Developer quick start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ OpenSlideX 是开源、local-first 的可编辑演示文稿工作区。每份演
 
 ## 无需 Node.js 或 Git 的安装方式
 
-独立安装程序会下载完整 OpenSlideX runtime，包括私有 Node.js 可执行文件和 Chromium renderer；不会安装 npm、Git 或系统级 Node.js，也无需管理员权限。
+独立安装程序会下载完整 OpenSlideX runtime，包括私有 Node.js 可执行文件和 Chromium renderer；不会安装 npm、Git 或系统级 Node.js。Windows 如需安装 GitHub CLI 来验证 release，可能会请求系统授权。
 
 macOS：
 
@@ -28,7 +28,6 @@ Windows PowerShell：
 
 ```powershell
 irm https://github.com/zz41354899/open-slidex/releases/latest/download/install.ps1 -OutFile install.ps1
-gh attestation verify install.ps1 --repo zz41354899/open-slidex
 .\install.ps1
 ```
 
@@ -41,7 +40,7 @@ slidex rollback    # 切回保留的上一个正常版本
 slidex uninstall   # 移除 runtime 和命令，保留你的演示文稿
 ```
 
-macOS 的默认演示文稿库为 `~/Documents/OpenSlideX Workspace`；Windows 则位于当前用户的 Documents 文件夹。每个下载的 release archive 都会先通过 SHA-256 checksum 验证。
+macOS 的默认演示文稿库为 `~/Documents/OpenSlideX Workspace`；Windows 则位于当前用户的 Documents 文件夹。每个下载的 release archive 都会先通过 SHA-256 checksum 和 GitHub artifact attestation 验证。Windows 缺少 GitHub CLI（`gh`）时，安装程序会通过 Windows Package Manager（`winget`）安装它，再验证 release；macOS 需要预先提供 `gh`。
 
 ## 开发者快速开始
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,7 +14,7 @@ OpenSlideX 是開源、local-first 的可編輯簡報工作區。每一份簡報
 
 ## 不需要 Node.js 或 Git 的安裝方式
 
-獨立安裝程式會下載完整的 OpenSlideX 執行環境，包括私有的 Node.js 執行檔與 Chromium renderer；不會安裝 npm、Git 或系統層級的 Node.js，也不需要管理員權限。
+獨立安裝程式會下載完整的 OpenSlideX 執行環境，包括私有的 Node.js 執行檔與 Chromium renderer；不會安裝 npm、Git 或系統層級的 Node.js。Windows 若需安裝 GitHub CLI 進行 release 驗證，可能會要求系統授權。
 
 macOS：
 
@@ -28,7 +28,6 @@ Windows PowerShell：
 
 ```powershell
 irm https://github.com/zz41354899/open-slidex/releases/latest/download/install.ps1 -OutFile install.ps1
-gh attestation verify install.ps1 --repo zz41354899/open-slidex
 .\install.ps1
 ```
 
@@ -41,7 +40,7 @@ slidex rollback    # 切回保留的上一個正常版本
 slidex uninstall   # 移除執行環境與指令，保留你的簡報
 ```
 
-預設簡報庫在 macOS 為 `~/Documents/OpenSlideX Workspace`，Windows 則在目前使用者的 Documents 資料夾。每個下載的 release archive 必須同時通過 SHA-256 checksum 與 GitHub artifact attestation 才能切換目前版本，並會附上經 attestation 綁定的 SPDX SBOM。因此從 GitHub 正式安裝時需要 GitHub CLI（`gh`）；本機測試 mirror 則走明確隔離的測試路徑。
+預設簡報庫在 macOS 為 `~/Documents/OpenSlideX Workspace`，Windows 則在目前使用者的 Documents 資料夾。每個下載的 release archive 必須同時通過 SHA-256 checksum 與 GitHub artifact attestation 才能切換目前版本，並會附上經 attestation 綁定的 SPDX SBOM。Windows 在需要時會以 Windows Package Manager（`winget`）安裝 GitHub CLI（`gh`），再驗證 release；macOS 則需要預先提供 `gh`。本機測試 mirror 仍走明確隔離的測試路徑。
 
 ## 開發者快速開始
 

--- a/install.ps1
+++ b/install.ps1
@@ -48,6 +48,54 @@ function Assert-NotReparsePoint([string]$Path, [string]$Message) {
   }
 }
 
+function Find-GitHubCli([switch]$RefreshPath) {
+  $Gh = Get-Command gh -ErrorAction SilentlyContinue
+  if ($Gh) { return $Gh.Source }
+
+  if (-not $RefreshPath) { return $null }
+
+  $UserPath = (Get-ItemProperty -Path "HKCU:\Environment" -Name Path -ErrorAction SilentlyContinue).Path
+  $MachinePath = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name Path -ErrorAction SilentlyContinue).Path
+  $PathEntries = @($env:Path, $UserPath, $MachinePath) |
+    Where-Object { $_ } |
+    ForEach-Object { $_ -split ';' } |
+    Where-Object { $_ } |
+    ForEach-Object { [Environment]::ExpandEnvironmentVariables($_) }
+  $env:Path = ($PathEntries | Select-Object -Unique) -join ';'
+
+  $Gh = Get-Command gh -ErrorAction SilentlyContinue
+  if ($Gh) { return $Gh.Source }
+
+  $Candidates = @(
+    (Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links\gh.exe"),
+    (Join-Path $env:ProgramFiles "GitHub CLI\gh.exe")
+  )
+  if (${env:ProgramFiles(x86)}) {
+    $Candidates += Join-Path ${env:ProgramFiles(x86)} "GitHub CLI\gh.exe"
+  }
+  return $Candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+}
+
+function Install-GitHubCli {
+  $GhPath = Find-GitHubCli
+  if ($GhPath) { return $GhPath }
+
+  $Winget = Get-Command winget -ErrorAction SilentlyContinue
+  if (-not $Winget) {
+    throw "GitHub CLI is required to verify the release attestation, and Windows Package Manager (winget) is unavailable. Install GitHub CLI from https://cli.github.com/, then run the installer again."
+  }
+
+  Write-Host "OpenSlideX is installing GitHub CLI with winget to verify the release attestation..."
+  & $Winget.Source install --id GitHub.cli --exact --source winget --accept-source-agreements --accept-package-agreements
+  if ($LASTEXITCODE -ne 0) { throw "GitHub CLI installation with winget failed. Approve any Windows elevation prompt, or install GitHub CLI from https://cli.github.com/, then run the installer again." }
+
+  $GhPath = Find-GitHubCli -RefreshPath
+  if (-not $GhPath) {
+    throw "GitHub CLI was installed but is not available to this PowerShell session. Open a new PowerShell window, then run the installer again."
+  }
+  return $GhPath
+}
+
 function Assert-SafeZip([string]$ArchivePath, [string]$DestinationRoot) {
   Add-Type -AssemblyName System.IO.Compression.FileSystem
   $DestinationFull = [IO.Path]::GetFullPath($DestinationRoot).TrimEnd('\', '/')
@@ -109,9 +157,8 @@ try {
   $ActualSha = (Get-FileHash -Algorithm SHA256 -LiteralPath $ArchivePath).Hash.ToLowerInvariant()
   if ($ExpectedSha -cne $ActualSha) { throw "OpenSlideX download checksum verification failed. Nothing was installed." }
   if ($ReleaseBaseUrl -ceq $DefaultReleaseBaseUrl) {
-    $Gh = Get-Command gh -ErrorAction SilentlyContinue
-    if (-not $Gh) { throw "GitHub CLI is required to verify the release attestation. Install gh, then run the installer again." }
-    & $Gh.Source attestation verify $ArchivePath --repo $Repository | Out-Null
+    $GhPath = Install-GitHubCli
+    & $GhPath attestation verify $ArchivePath --repo $Repository | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "OpenSlideX release provenance verification failed. Nothing was installed." }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-slidex",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-slidex",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "workspaces": [
         "packages/editor-ui",
         "packages/open-slidex",
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -724,13 +724,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -746,20 +746,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -820,9 +820,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -858,9 +858,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -896,9 +896,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -974,13 +974,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -999,13 +999,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1024,13 +1024,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1049,13 +1049,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1074,13 +1074,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1099,13 +1099,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1124,13 +1124,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1149,17 +1149,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1169,16 +1169,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1188,9 +1188,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -5918,9 +5918,9 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
@@ -5934,31 +5934,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -6650,7 +6650,7 @@
     },
     "packages/editor-ui": {
       "name": "@open-slidex/editor-ui",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6666,7 +6666,7 @@
       }
     },
     "packages/open-slidex": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
@@ -6717,12 +6717,12 @@
     },
     "packages/open-slidex-mcp": {
       "name": "@open-slidex/mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0",
         "@napi-rs/canvas": "0.1.100",
-        "@open-slidex/sdk": "0.6.0",
+        "@open-slidex/sdk": "0.6.1",
         "esbuild": "^0.28.0",
         "mdast-util-from-markdown": "2.0.3",
         "pdf-to-img": "5.0.0",
@@ -7268,7 +7268,7 @@
     },
     "packages/slidex-sdk": {
       "name": "@open-slidex/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.28.0",
@@ -7288,14 +7288,14 @@
     },
     "packages/slidex-workbench": {
       "name": "@open-slidex/workbench",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lang-markdown": "^6.5.0",
         "@fontsource/roboto": "^5.2.8",
-        "@open-slidex/editor-ui": "0.6.0",
+        "@open-slidex/editor-ui": "0.6.1",
         "@tailwindcss/postcss": "4.3.0",
         "@uiw/react-codemirror": "^4.25.10",
         "@vitejs/plugin-react": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-slidex",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "workspaces": [
     "packages/editor-ui",
     "packages/open-slidex",

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/editor-ui",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/open-slidex-mcp/package.json
+++ b/packages/open-slidex-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/mcp",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Local-only MCP server for an OpenSlideX presentation workspace.",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",
     "@napi-rs/canvas": "0.1.100",
-    "@open-slidex/sdk": "0.6.0",
+    "@open-slidex/sdk": "0.6.1",
     "esbuild": "^0.28.0",
     "mdast-util-from-markdown": "2.0.3",
     "pdf-to-img": "5.0.0",

--- a/packages/open-slidex/package.json
+++ b/packages/open-slidex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-slidex",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Create a local-first React presentation workspace with portable MDX export.",
   "type": "module",
   "bin": {

--- a/packages/open-slidex/template/package.json
+++ b/packages/open-slidex/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "__PROJECT_NAME__",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/packages/slidex-sdk/package.json
+++ b/packages/slidex-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/sdk",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MotionDoc authoring, revision, inspection, rendering, and export primitives for OpenSlideX.",
   "type": "module",
   "bin": {

--- a/packages/slidex-workbench/package.json
+++ b/packages/slidex-workbench/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/workbench",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Local React-first OpenSlideX presentation workbench.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-markdown": "^6.5.0",
     "@fontsource/roboto": "^5.2.8",
-    "@open-slidex/editor-ui": "0.6.0",
+    "@open-slidex/editor-ui": "0.6.1",
     "@tailwindcss/postcss": "4.3.0",
     "@uiw/react-codemirror": "^4.25.10",
     "@vitejs/plugin-react": "^6.0.4",

--- a/scripts/standalone-release.test.mjs
+++ b/scripts/standalone-release.test.mjs
@@ -93,9 +93,10 @@ test("standalone dependency records must match the reviewed lock path, version, 
 });
 
 test("bootstrap scripts expose immutable update, rollback, identity, and checksum contracts", async () => {
-  const [shellInstaller, powershellInstaller, readme, manifest, releaseWorkflow, securityWorkflow] = await Promise.all([
+  const [shellInstaller, powershellInstaller, windowsInstallerTest, readme, manifest, releaseWorkflow, securityWorkflow] = await Promise.all([
     readFile(path.join(repositoryRoot, "install.sh"), "utf8"),
     readFile(path.join(repositoryRoot, "install.ps1"), "utf8"),
+    readFile(path.join(repositoryRoot, "scripts/test-standalone-windows.ps1"), "utf8"),
     readFile(path.join(repositoryRoot, "README.md"), "utf8"),
     readFile(path.join(repositoryRoot, "package.json"), "utf8").then(JSON.parse),
     readFile(path.join(repositoryRoot, ".github/workflows/standalone-release.yml"), "utf8"),
@@ -115,6 +116,12 @@ test("bootstrap scripts expose immutable update, rollback, identity, and checksu
   assert.match(powershellInstaller, /\$Command -eq "uninstall"/);
   assert.match(powershellInstaller, /Assert-SafeZip/);
   assert.match(powershellInstaller, /attestation verify/);
+  assert.match(powershellInstaller, /function Install-GitHubCli/);
+  assert.match(powershellInstaller, /winget to verify the release attestation/);
+  assert.match(powershellInstaller, /install --id GitHub\.cli --exact --source winget/);
+  assert.match(powershellInstaller, /--accept-source-agreements --accept-package-agreements/);
+  assert.match(windowsInstallerTest, /install-with-local-attestation/);
+  assert.match(windowsInstallerTest, /Missing GitHub CLI did not invoke winget/);
   assert.doesNotMatch(powershellInstaller, /raw\.githubusercontent\.com/);
   assert.match(readme, /slidex update/);
   assert.match(readme, /slidex uninstall/);

--- a/scripts/test-standalone-windows.ps1
+++ b/scripts/test-standalone-windows.ps1
@@ -105,6 +105,33 @@ try {
   if (Test-Path -LiteralPath $env:OPEN_SLIDEX_INSTALL_ROOT) { throw "Install root still exists after uninstall." }
   if (-not (Test-Path -LiteralPath $env:OPEN_SLIDEX_WORKSPACE)) { throw "Workspace was removed during uninstall." }
 
+  $FakeBin = Join-Path $Root "fake-bin"
+  $FakeGh = Join-Path $FakeBin "gh.cmd"
+  $FakeGhSource = Join-Path $Root "fake-gh-source.cmd"
+  $FakeWinget = Join-Path $FakeBin "winget.cmd"
+  $WingetMarker = Join-Path $Root "winget-invoked"
+  $BootstrapInstaller = Join-Path $Root "install-with-local-attestation.ps1"
+  New-Item -ItemType Directory -Path $FakeBin -Force | Out-Null
+  Set-Content -LiteralPath $FakeGhSource -Value "@echo off`r`nexit /b 0" -Encoding ASCII
+  Set-Content -LiteralPath $FakeWinget -Value "@echo off`r`ncopy /Y `"$FakeGhSource`" `"$FakeGh`" >NUL`r`ncopy NUL `"$WingetMarker`" >NUL`r`nexit /b 0" -Encoding ASCII
+  $InstallerSource = Get-Content -LiteralPath (Join-Path $RepositoryRoot "install.ps1") -Raw
+  $InstallerSource = $InstallerSource.Replace('$DefaultReleaseBaseUrl = "https://github.com/$Repository/releases/latest/download"', '$DefaultReleaseBaseUrl = $env:OPEN_SLIDEX_RELEASE_BASE_URL')
+  Set-Content -LiteralPath $BootstrapInstaller -Value $InstallerSource -Encoding UTF8
+  $OriginalPath = $env:Path
+  try {
+    $env:Path = $FakeBin
+    $env:OPEN_SLIDEX_INSTALL_ROOT = Join-Path $Root "bootstrap-installed"
+    $env:OPEN_SLIDEX_WORKSPACE = Join-Path $Root "bootstrap-workspace"
+    & $BootstrapInstaller
+    if (-not (Test-Path -LiteralPath $WingetMarker)) { throw "Missing GitHub CLI did not invoke winget." }
+    $BootstrapLauncher = Join-Path $env:OPEN_SLIDEX_INSTALL_ROOT "slidex.cmd"
+    if (-not (Test-Path -LiteralPath $BootstrapLauncher)) { throw "Missing GitHub CLI did not complete installation." }
+    $env:Path = $OriginalPath
+    & $BootstrapLauncher uninstall | Out-Null
+  } finally {
+    $env:Path = $OriginalPath
+  }
+
   Add-Type -AssemblyName System.IO.Compression.FileSystem
   $Sentinel = Join-Path $Root "outside-sentinel"
   Set-Content -LiteralPath $Sentinel -Value "safe" -Encoding ASCII


### PR DESCRIPTION
## Summary\n- install GitHub CLI with winget when Windows lacks gh\n- preserve SHA-256 and GitHub attestation verification\n- release OpenSlideX 0.6.1\n\n## Verification\n- npm ci --ignore-scripts --dry-run\n- npm run test:standalone\n- npm run build:runtime\n- node scripts/verify-open-slidex-release.mjs\n- git diff --check