### PR TITLE
fix: retain the 0.6.0 runtime version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-slidex",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-slidex",
-      "version": "0.6.1",
+      "version": "0.6.0",
       "workspaces": [
         "packages/editor-ui",
         "packages/open-slidex",
@@ -6650,7 +6650,7 @@
     },
     "packages/editor-ui": {
       "name": "@open-slidex/editor-ui",
-      "version": "0.6.1",
+      "version": "0.6.0",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6666,7 +6666,7 @@
       }
     },
     "packages/open-slidex": {
-      "version": "0.6.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
@@ -6717,12 +6717,12 @@
     },
     "packages/open-slidex-mcp": {
       "name": "@open-slidex/mcp",
-      "version": "0.6.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0",
         "@napi-rs/canvas": "0.1.100",
-        "@open-slidex/sdk": "0.6.1",
+        "@open-slidex/sdk": "0.6.0",
         "esbuild": "^0.28.0",
         "mdast-util-from-markdown": "2.0.3",
         "pdf-to-img": "5.0.0",
@@ -7268,7 +7268,7 @@
     },
     "packages/slidex-sdk": {
       "name": "@open-slidex/sdk",
-      "version": "0.6.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.28.0",
@@ -7288,14 +7288,14 @@
     },
     "packages/slidex-workbench": {
       "name": "@open-slidex/workbench",
-      "version": "0.6.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lang-markdown": "^6.5.0",
         "@fontsource/roboto": "^5.2.8",
-        "@open-slidex/editor-ui": "0.6.1",
+        "@open-slidex/editor-ui": "0.6.0",
         "@tailwindcss/postcss": "4.3.0",
         "@uiw/react-codemirror": "^4.25.10",
         "@vitejs/plugin-react": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-slidex",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.0",
   "workspaces": [
     "packages/editor-ui",
     "packages/open-slidex",

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/editor-ui",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/open-slidex-mcp/package.json
+++ b/packages/open-slidex-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/mcp",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "Local-only MCP server for an OpenSlideX presentation workspace.",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",
     "@napi-rs/canvas": "0.1.100",
-    "@open-slidex/sdk": "0.6.1",
+    "@open-slidex/sdk": "0.6.0",
     "esbuild": "^0.28.0",
     "mdast-util-from-markdown": "2.0.3",
     "pdf-to-img": "5.0.0",

--- a/packages/open-slidex/package.json
+++ b/packages/open-slidex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-slidex",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "Create a local-first React presentation workspace with portable MDX export.",
   "type": "module",
   "bin": {

--- a/packages/open-slidex/template/package.json
+++ b/packages/open-slidex/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "__PROJECT_NAME__",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/packages/slidex-sdk/package.json
+++ b/packages/slidex-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/sdk",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "MotionDoc authoring, revision, inspection, rendering, and export primitives for OpenSlideX.",
   "type": "module",
   "bin": {

--- a/packages/slidex-workbench/package.json
+++ b/packages/slidex-workbench/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-slidex/workbench",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "Local React-first OpenSlideX presentation workbench.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-markdown": "^6.5.0",
     "@fontsource/roboto": "^5.2.8",
-    "@open-slidex/editor-ui": "0.6.1",
+    "@open-slidex/editor-ui": "0.6.0",
     "@tailwindcss/postcss": "4.3.0",
     "@uiw/react-codemirror": "^4.25.10",
     "@vitejs/plugin-react": "^6.0.4",


### PR DESCRIPTION
Restores all package, workspace, starter, and lockfile version metadata to 0.6.0 while retaining the Windows installer repair and the sharp 0.35.4 security update. No release tag is created.\n\nVerified with npm ci --ignore-scripts, npm run test:standalone, npm audit --omit=dev --audit-level=moderate, and git diff --check.