### PR TITLE
fix: download standalone provenance bundles reliably

### DIFF
--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -169,7 +169,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           for asset in open-slidex-darwin-arm64.tar.gz open-slidex-darwin-x64.tar.gz open-slidex-windows-x64.zip; do
-            gh attestation download "$asset" --repo "$GH_REPO" --predicate-type https://slsa.dev/provenance/v1 --limit 1
+            gh attestation download "$asset" --repo "$GH_REPO"
             digest=$(sha256sum "$asset" | awk '{ print $1 }')
             mv "sha256:${digest}.jsonl" "${asset}.intoto.jsonl"
           done

--- a/scripts/standalone-release.test.mjs
+++ b/scripts/standalone-release.test.mjs
@@ -160,6 +160,7 @@ test("bootstrap scripts expose immutable update, rollback, identity, and checksu
   assert.match(releaseWorkflow, /Add offline provenance bundles/);
   assert.match(releaseWorkflow, /gh attestation download/);
   assert.match(releaseWorkflow, /\.intoto\.jsonl/);
+  assert.doesNotMatch(releaseWorkflow, /--predicate-type https:\/\/slsa\.dev\/provenance\/v1/);
   assert.doesNotMatch(releaseWorkflow, /npm publish/);
   assert.doesNotMatch(releaseWorkflow, /--clobber/);
   assert.match(securityWorkflow, /pull_request:/);


### PR DESCRIPTION
Fix the release publisher to download the generated attestation bundles without an overly narrow predicate filter.

This preserves offline installer verification and prevents future standalone releases from failing while creating bundle assets.

Verified: npm run test:standalone.